### PR TITLE
Update ntlm.ts for 

### DIFF
--- a/api/handlers/ntlm.ts
+++ b/api/handlers/ntlm.ts
@@ -14,14 +14,14 @@ export class NtlmCredentialHandler implements VsoBaseInterfaces.IRequestHandler 
     workstation: string;
     domain: string;
 
-    constructor(username: string, password: string,  domain?: string, workstation?: string) {
+    constructor(username: string, password: string,  workstation?: string, domain?: string) {
         this.username = username;
         this.password = password;
-        if (domain !== undefined) {
-            this.domain = domain;
-        }
         if (workstation !== undefined) {
             this.workstation = workstation;
+        }
+        if (domain !== undefined) {
+            this.domain = domain;
         }
     }
 


### PR DESCRIPTION
WebApi.ts  new NtlmCredetialHandler initializatin was wrong at line39. workstation and domain order parameters were reverse order.
But it is exported in that order, that's why I changed the constructor according to this.